### PR TITLE
Native palette buffer

### DIFF
--- a/include/lanternapi.h
+++ b/include/lanternapi.h
@@ -364,6 +364,11 @@ extern "C"
 	 */
 	API void palette_from_mix(int index, int index_source, Uint8 r, Uint8 g, Uint8 b, bool specular, bool apply);
 
+	 /**
+	 * \brief Rebuilds the palette atlas. Required for changes to be visible when palette data is modified directly.
+	 */
+	API void generate_atlas();
+
 #ifdef __cplusplus
 }
 #endif

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -438,16 +438,15 @@ bool LanternInstance::load_palette(const std::string& path)
 
 	file.close();
 
-	unsigned int maxlength = palette_index_count * palette_index_length;
-	if (color_data.size() > maxlength)
+	if (color_data.size() > palette_pairs_max)
 	{
-		PrintDebug("[lantern] WARNING: Palette size %d exceeds standard maximum of %d.\n", color_data.size(), maxlength);
+		PrintDebug("[lantern] WARNING: Palette size %u exceeds standard maximum of %u.\n", color_data.size(), palette_pairs_max);
 	}
 
-	memset(LSPAL.data(), 0, sizeof(ColorPair) * maxlength);
+	memset(LSPAL.data(), 0, sizeof(ColorPair) * palette_pairs_max);
 	memcpy(LSPAL.data(),
 		color_data.data(),
-		std::min(sizeof(ColorPair) * color_data.size(), sizeof(ColorPair) * maxlength));
+		std::min(sizeof(ColorPair) * color_data.size(), sizeof(ColorPair) * palette_pairs_max));
 	generate_atlas();
 	return true;
 }

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -15,7 +15,12 @@
 #include "datapointers.h"
 #include "lantern.h"
 
-DataArray(ColorPair[256], LSPAL, 0x3B12210, 8);
+// The game's palette data array which contains 8+2 palette pairs.
+// The extra pairs were used on DC for backups via lig_cpyPalette.
+// The PC version only uses one extra pair to store stage palettes.
+// It is used in Gamma's briefing cutscene when the lights turn off.
+// The extra pairs are never cleared on DC and in this mod.
+DataArray(ColorPair[256], LSPAL, 0x3B12210, 10);
 
 bool SourceLight_t::operator==(const SourceLight_t& rhs) const
 {

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -15,7 +15,7 @@
 #include "datapointers.h"
 #include "lantern.h"
 
-DataArray(ColorPair[256], LSPAL, 0x3B12210, 10);
+DataArray(ColorPair[256], LSPAL, 0x3B12210, 8);
 
 bool SourceLight_t::operator==(const SourceLight_t& rhs) const
 {

--- a/sadx-dc-lighting/lantern.h
+++ b/sadx-dc-lighting/lantern.h
@@ -186,6 +186,7 @@ public:
 	void palette_from_rgb(int index, Uint8 r, Uint8 g, Uint8 b, bool specular, bool apply);
 	void palette_from_array(int index, const NJS_ARGB* colors, bool specular, bool apply);
 	void palette_from_mix(int index, int index_source, Uint8 r, Uint8 g, Uint8 b, bool specular, bool apply);
+	void generate_atlas();
 	void add_pl_callback(lantern_load_cb callback);
 	void remove_pl_callback(lantern_load_cb callback);
 	void add_sl_callback(lantern_load_cb callback);
@@ -193,7 +194,6 @@ public:
 	bool run_pl_callbacks(Sint32 level, Sint32 act, Sint8 time);
 	bool run_sl_callbacks(Sint32 level, Sint32 act, Sint8 time);
 	bool load_files();
-	void generate_atlas();
 
 	// TODO: Expose to API when explicit multi-palette management is implemented.
 	// TODO: Rewrite and reformat documentation below.

--- a/sadx-dc-lighting/lantern.h
+++ b/sadx-dc-lighting/lantern.h
@@ -99,6 +99,11 @@ public:
 	static constexpr size_t palette_index_length = 256;
 
 	/**
+	 * \brief The maximum number of color pairs in a PL file.
+	 */
+	static constexpr size_t palette_pairs_max = palette_index_count * palette_index_length;
+
+	/**
 	 * \brief The maximum number of source lights.
 	 */
 	static constexpr size_t source_light_count = 16;

--- a/sadx-dc-lighting/lantern.h
+++ b/sadx-dc-lighting/lantern.h
@@ -106,7 +106,6 @@ public:
 private:
 	// TODO: handle externally
 	ShaderParameter<Texture>* atlas_;
-	std::array<ColorPair, palette_index_count * palette_index_length> palette_pairs_ {};
 	std::array<SourceLight, source_light_count> source_lights_ {};
 	NJS_VECTOR sl_direction_ {};
 
@@ -189,6 +188,7 @@ public:
 	bool run_pl_callbacks(Sint32 level, Sint32 act, Sint8 time);
 	bool run_sl_callbacks(Sint32 level, Sint32 act, Sint8 time);
 	bool load_files();
+	void generate_atlas();
 
 	// TODO: Expose to API when explicit multi-palette management is implemented.
 	// TODO: Rewrite and reformat documentation below.

--- a/sadx-dc-lighting/lanternapi.cpp
+++ b/sadx-dc-lighting/lanternapi.cpp
@@ -283,3 +283,8 @@ void palette_from_mix(int index, int index_source, Uint8 r, Uint8 g, Uint8 b, bo
 {
 	globals::palettes.palette_from_mix(index, index_source, r, g, b, specular, apply);
 }
+
+void generate_atlas()
+{
+	globals::palettes.generate_atlas();
+}

--- a/sadx-dc-lighting/mod.cpp
+++ b/sadx-dc-lighting/mod.cpp
@@ -37,6 +37,9 @@ static Trampoline* SetTimeOfDay_t                  = nullptr;
 static Trampoline* Direct3D_SetTexList_t           = nullptr;
 static Trampoline* SetCurrentStageLights_t         = nullptr;
 static Trampoline* SetCurrentStageLight_EggViper_t = nullptr;
+static Trampoline* lig_convHalfBrightPalette_t     = nullptr;
+static Trampoline* lig_fillOffsetPalette_t         = nullptr;
+static Trampoline* lig_supplementPalette_t         = nullptr;
 
 DataPointer(NJS_VECTOR, NormalScaleMultiplier, 0x03B121F8);
 
@@ -262,6 +265,24 @@ static void __cdecl SetLevelAndAct_r(Uint8 level, Uint8 act)
 {
 	TARGET_DYNAMIC(SetLevelAndAct)(level, act);
 	globals::palettes.load_files();
+}
+
+static void __cdecl lig_convHalfBrightPalette_r(int no, float rate)
+{
+	TARGET_DYNAMIC(lig_convHalfBrightPalette)(no, rate);
+	globals::palettes.generate_atlas();
+}
+
+static void __cdecl lig_fillOffsetPalette_r(int no, int spe, int num)
+{
+	TARGET_DYNAMIC(lig_fillOffsetPalette)(no, spe, num);
+	globals::palettes.generate_atlas();
+}
+
+static void __cdecl lig_supplementPalette_r(int no, int src1, int src2, float fmix1)
+{
+	TARGET_DYNAMIC(lig_supplementPalette)(no, src1, src2, fmix1);
+	globals::palettes.generate_atlas();
 }
 
 static void __cdecl GoToNextChaoStage_r()
@@ -538,6 +559,9 @@ extern "C"
 		Direct3D_SetTexList_t           = new Trampoline(0x0077F3D0, 0x0077F3D8, Direct3D_SetTexList_r);
 		SetCurrentStageLights_t         = new Trampoline(0x0040A950, 0x0040A955, SetCurrentStageLights_r);
 		SetCurrentStageLight_EggViper_t = new Trampoline(0x0057E560, 0x0057E567, SetCurrentStageLight_EggViper_r);
+		lig_convHalfBrightPalette_t     = new Trampoline(0x004123C0, 0x004123C7, lig_convHalfBrightPalette_r);
+		lig_fillOffsetPalette_t         = new Trampoline(0x00412180, 0x00412188, lig_fillOffsetPalette_r);
+		lig_supplementPalette_t         = new Trampoline(0x00412280, 0x00412287, lig_supplementPalette_r);
 
 		// Material callback hijack
 		WriteJump(reinterpret_cast<void*>(0x0040A340), CorrectMaterial_r);

--- a/sadx-dc-lighting/mod.ini
+++ b/sadx-dc-lighting/mod.ini
@@ -1,6 +1,6 @@
 Name=Lantern Engine
 Author=x-hax
-Version=1.5.6
+Version=1.6.0
 Description=Re-implementation of the Dreamcast Sonic Adventure's palette-based lighting system.
 DLLFile=sadx-dc-lighting.dll
 GitHubRepo=sonicfreak94/sadx-dc-lighting


### PR DESCRIPTION
This PR makes the mod use the game's leftover palette data array instead of storing palette pairs in LanternInstance. This enables integration with the game's own palette mixing code which is still functional: 
`lig_convHalfBrightPalette` (0x004123C0) reduces the brightness of all colors in a palette. It's used for the lights in Gamma's briefing cutscene.
`lig_fillOffsetPalette` (0x00412180) fills a palette with a specific color. It's used in Casino when Sonic is transported to pinball stages.
`lig_supplementPalette` (0x00412280) fills a palette with colors resulting from blending two other palettes. It's used by a debug object in Station Square called LightChanger.
`lig_cpyPalette` (0x00412210) copies one palette to another. It's used for backing up and restoring the original palettes in Gamma's briefing cutscene. This function isn't hooked so if it's used on its own, palette atlas regeneration must be done manually.

More sophisticated effects can be created by using these functions in mods, though I suspect blending is going to be slower than with Lantern API.

Should be fully compatible with mods that already use the API.